### PR TITLE
Add configuration for CS pin for Ethernet W5500

### DIFF
--- a/build_flags_template.sh
+++ b/build_flags_template.sh
@@ -24,5 +24,6 @@
 # export FLAGS="$FLAGS -DRESET_PIN=5"
 # export FLAGS="$FLAGS -DDHCP_RETRY_INTERVAL=60000"
 # export FLAGS="$FLAGS -DRESTART_LAN_ON_MQTT_ERRORS"
+# export FLAGS="$FLAGS -DW5500_CS_PIN=53"
  export FLAGS="$FLAGS -DPIO_SRC_REV="$(git log --pretty=format:%h_%ad -1 --date=short)
  echo $FLAGS

--- a/lighthub/main.cpp
+++ b/lighthub/main.cpp
@@ -493,6 +493,11 @@ void onInitialStateInitLAN() {
 #endif
 
 #if defined(__AVR__) || defined(__SAM3X8E__)||defined(ARDUINO_ARCH_STM32F1)
+#ifdef W5500_CS_PIN
+    Ethernet.w5500_cspin = W5500_CS_PIN;
+    debugSerial.print(F("Use W5500 pin: "));
+    debugSerial.println(Ethernet.w5500_cspin);
+#endif
     IPAddress ip, dns, gw, mask;
     int res = 1;
     debugSerial.println(F("Starting lan"));


### PR DESCRIPTION
Ethernet2 library for W5100/W5500 use pin 10 as SPI CS. If you compare Arduino Uno (http://forum.arduino.cc/index.php/topic,84190.0.html) and Arduino Mega (https://forum.arduino.cc/index.php?topic=125908.0) pinouts then you can see thas 10 is Uno CS pin but for Mega use 53.
This merge request add flag which allows to configure pin 53 as CS for Mega board.